### PR TITLE
Allow Parse::CSV to accept allow_loose_quotes

### DIFF
--- a/lib/Parse/CSV.pm
+++ b/lib/Parse/CSV.pm
@@ -228,7 +228,7 @@ sub new {
 	unless ( Params::Util::_HASH0($self->{csv_attr}) ) {
 		$self->{csv_attr} = {binary => 1};  # Suggested by Text::CSV_XS docs to always be on
 		# XXX it would be nice to not have this list hard-coded.
-		foreach ( qw{quote_char eol escape_char sep_char binary always_quote} ) {
+		foreach ( qw{quote_char eol escape_char sep_char binary always_quote allow_loose_quotes} ) {
 			next unless exists $self->{$_};
 			$self->{csv_attr}->{$_} = delete $self->{$_};
 		}


### PR DESCRIPTION
I'd like to utilize the allow_loose_quotes param when Parse::CSV creates the Text::CSV object. This commit is simple and should allow someone to pass it to Parse::CSV->new if they want to.